### PR TITLE
MWAB-77: Addressed the image_hash method

### DIFF
--- a/app/models/dev_site.rb
+++ b/app/models/dev_site.rb
@@ -92,6 +92,7 @@ class DevSite < ActiveRecord::Base
   end
 
   def image_hash
+    return if self.images.empty?
     self.images.map do |img|
       dimensions = FastImage.size(img.url)
       { src: img.url, w: dimensions.first, h: dimensions.last }

--- a/spec/models/dev_site_spec.rb
+++ b/spec/models/dev_site_spec.rb
@@ -19,6 +19,8 @@ describe DevSite do
   it { should respond_to(:files) }
   it { should respond_to(:images) }
 
+  it { should respond_to(:image_hash) }
+
   it { should be_valid }
 
 end


### PR DESCRIPTION
Fixing this method as it was causing errors:

![image](https://cloud.githubusercontent.com/assets/6380439/16783939/70b1b85a-4854-11e6-8036-c958c6bbd9d7.png)

doesn't make sense that we performed the function even though images might be empty
