### PR TITLE
gzip everything and optimize by calling it in prod and dev env

### DIFF
--- a/app/client/webpack.dev.config.js
+++ b/app/client/webpack.dev.config.js
@@ -2,6 +2,9 @@ const webpack = require('webpack');
 const path = require('path');
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const CompressionPlugin = require('compression-webpack-plugin');
+const express = require('express');
+const app = express();
 
 module.exports = {
 
@@ -20,7 +23,22 @@ module.exports = {
   },
 
   plugins: [
-    new ExtractTextPlugin('[name].css')
+    new ExtractTextPlugin('[name].css'),
+    // new webpack.DefinePlugin({ // <-- key to reducing React's size
+    //   'process.env': {
+    //     'NODE_ENV': JSON.stringify('production')
+    //   }
+    // }),
+    new webpack.optimize.DedupePlugin(), //dedupe similar code
+    new webpack.optimize.UglifyJsPlugin(), //minify everything
+    new webpack.optimize.AggressiveMergingPlugin(),//Merge chunks
+    new CompressionPlugin({
+      asset: "[path].gz[query]",
+      algorithm: "gzip",
+      test: /\.js$|\.css$|\.html$/,
+      threshold: 10240,
+      minRatio: 0.8
+    })
   ],
 
   module: {
@@ -66,3 +84,9 @@ module.exports = {
 
   sassResources: ['../assets/stylesheets/variables.scss']
 }
+
+app.get('*.js', function (req, res, next) {
+  req.url = req.url + '.gz';
+  res.set('Content-Encoding', 'gzip');
+  next();
+});

--- a/app/client/webpack.prod.config.js
+++ b/app/client/webpack.prod.config.js
@@ -2,6 +2,8 @@ const webpack = require('webpack');
 const path = require("path");
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const express = require('express');
+const app = express();
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 
@@ -30,6 +32,14 @@ module.exports = {
         NODE_ENV: JSON.stringify('production'),
         ENV: JSON.stringify(ENV)
       }
+    }),
+    new webpack.optimize.AggressiveMergingPlugin(),//Merge chunks
+    new CompressionPlugin({
+      asset: "[path].gz[query]",
+      algorithm: "gzip",
+      test: /\.js$|\.css$|\.html$/,
+      threshold: 10240,
+      minRatio: 0.8
     })
   ],
 
@@ -76,3 +86,9 @@ module.exports = {
 
   sassResources: ['../assets/stylesheets/variables.scss']
 }
+
+app.get('*.js', function (req, res, next) {
+  req.url = req.url + '.gz';
+  res.set('Content-Encoding', 'gzip');
+  next();
+});

--- a/app/client/webpack.prod.config.js
+++ b/app/client/webpack.prod.config.js
@@ -2,8 +2,6 @@ const webpack = require('webpack');
 const path = require("path");
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const express = require('express');
-const app = express();
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 
@@ -86,9 +84,3 @@ module.exports = {
 
   sassResources: ['../assets/stylesheets/variables.scss']
 }
-
-app.get('*.js', function (req, res, next) {
-  req.url = req.url + '.gz';
-  res.set('Content-Encoding', 'gzip');
-  next();
-});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^7.1.1",
+    "compression-webpack-plugin": "^1.0.0",
     "eslint": "3.2.2",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-import": "1.12.0",


### PR DESCRIPTION
This should help us load webpack gzipped a lot faster.
It also guide us to optimization like unreachable code and many more.
For more information here is [medium article](https://medium.com/@rajaraodv/two-quick-ways-to-reduce-react-apps-size-in-production-82226605771a) that my changes refers to
It's possible as it looks from package.json that [express](https://github.com/expressjs/express) is not added there, you will need to`npm install express`