### PR TITLE
Dll prod

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
 resque: env TERM_CHILD=1 bundle exec rake resque:work QUEUE='*'
+webpack: (cd app/client && npm start)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: bundle exec puma -C config/puma.rb
 resque: env TERM_CHILD=1 bundle exec rake resque:work QUEUE='*'
-webpack: (cd app/client && npm start)

--- a/app/client/config.dll.js
+++ b/app/client/config.dll.js
@@ -1,0 +1,26 @@
+var path = require("path");
+var webpack = require("webpack");
+
+module.exports = {
+    entry: {
+        vendor: [path.join(__dirname, "vendors.js")]
+    },
+    output: {
+        path: path.join(__dirname, '../assets', 'javascripts', 'dist', 'dll'),
+        filename: "dll.[name].js",
+        library: "[name]"
+    },
+    plugins: [
+        new webpack.DllPlugin({
+            path: path.join(__dirname, '../assets', 'javascripts', "dll", "[name]-manifest.json"),
+            name: "[name]",
+            context: path.resolve(__dirname, '../assets', 'javascripts')
+        }),
+        new webpack.optimize.OccurenceOrderPlugin(),
+        new webpack.optimize.UglifyJsPlugin()
+    ],
+    resolve: {
+        root: path.resolve(__dirname, '../assets', 'javascripts'),
+        modulesDirectories: ["node_modules"]
+    }
+};

--- a/app/client/config.dll.js
+++ b/app/client/config.dll.js
@@ -14,13 +14,13 @@ module.exports = {
         new webpack.DllPlugin({
             path: path.join(__dirname, '../assets', 'javascripts', "dll", "[name]-manifest.json"),
             name: "[name]",
-            context: path.resolve(__dirname, '../assets', 'javascripts')
+            context: path.resolve(__dirname, '../assets', 'javascripts', 'dll')
         }),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.optimize.UglifyJsPlugin()
     ],
     resolve: {
-        root: path.resolve(__dirname, '../assets', 'javascripts'),
+        root: path.resolve(__dirname, '../client'),
         modulesDirectories: ["node_modules"]
     }
 };

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -4,8 +4,16 @@
   "description": "Milieu client directory",
   "scripts": {
     "start": "if-env NODE_ENV=production && npm run build:prod || npm run start:dev",
-    "build:prod": "webpack --config webpack.prod.config.js",
-    "start:dev": "webpack-dev-server --config webpack.dev.config.js --compress --host 0.0.0.0 --hot --inline --history-api-fallback"
+    "build:prod": "npm run clean && npm run build:dll && npm run build:webpack",
+    "postinstall": "webpack --config webpack.prod.config.js -p --progress --colors",
+    "prod": "NODE_ENV=production PORT=3000 node server.js",
+    "dev": "NODE_ENV=development PORT=8090 node server.js",
+    "start:dev": "webpack-dev-server --config webpack.dev.config.js --compress --host 0.0.0.0 --hot --inline --history-api-fallback",
+    "heroku-postbuild": "webpack -p --config webpack.prod.config.js --progress",
+    "clean": "rimraf dist",
+    "build:webpack": "webpack --config webpack.prod.config.js",
+    "build:dll": "webpack --config config.dll.js",
+    "build": "npm run clean && npm run build:dll && npm run build:webpack"
   },
   "repository": {
     "type": "git",
@@ -46,6 +54,7 @@
     "react-share": "^1.11.0",
     "react-tabs": "^1.0.0",
     "riek": "^1.0.7",
+    "rimraf": "^2.6.1",
     "sass-loader": "^3.2.0",
     "sass-resources-loader": "^1.0.2",
     "style-loader": "^0.13.1",

--- a/app/client/server.js
+++ b/app/client/server.js
@@ -1,0 +1,14 @@
+// in server.js
+const express = require('express');
+const app = express();
+const path = require('path');
+
+
+// Since the root/src dir contains our index.html
+app.use(express.static(path.join(__dirname, '../assets, javascripts')));
+
+// Heroku bydefault set an ENV variable called PORT=443
+//  so that you can access your site with https default port.
+// Falback port will be 8080; basically for pre-production test in localhost
+// You will use $ npm run prod for this
+app.listen(process.env.PORT || 8090);

--- a/app/client/vendors.js
+++ b/app/client/vendors.js
@@ -1,0 +1,4 @@
+require("classnames");
+require("lodash");
+require("react");
+require("react-dom"); 

--- a/app/client/webpack.prod.config.js
+++ b/app/client/webpack.prod.config.js
@@ -6,31 +6,40 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 
 module.exports = {
+  cache: true,
   entry: {
     bundle: path.resolve(__dirname, 'index')
   },
 
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
   },
 
   output: {
-    path: path.resolve(__dirname, "../assets/webpack"),
-    filename: "[name].js"
+    path: path.resolve(__dirname, '../assets', 'javascripts'),
+    publicPath: '/',
+    filename: "bundle.js"
   },
 
   plugins: [
     new webpack.NoErrorsPlugin(),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurrenceOrderPlugin(),
-    new webpack.optimize.UglifyJsPlugin(),
     new ExtractTextPlugin('[name].[hash].css'),
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify('production'),
         ENV: JSON.stringify(ENV)
       }
-    })
+    }),
+    new webpack.optimize.AggressiveMergingPlugin(),//Merge chunks
+    // new CompressionPlugin({
+    //   asset: "[path].gz[query]",
+    //   algorithm: "gzip",
+    //   test: /\.js$|\.css$|\.html$/,
+    //   threshold: 10240,
+    //   minRatio: 0.8
+    // })
   ],
 
   module: {
@@ -38,7 +47,15 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        loader: 'babel-loader?presets[]=es2015&presets[]=react&plugins[]=lodash'
+        loader: 'babel-loader?presets[]=es2015&presets[]=react&plugins[]=lodash',
+        include: [
+            path.join(__dirname, "client") //important for performance!
+        ],
+        query: {
+            cacheDirectory: true, //important for performance
+            plugins: ["transform-regenerator"],
+            presets: ["react", "es2015", "stage-0"]
+        }
       },
       {
         test: /\.(json|geojson)$/,
@@ -51,6 +68,12 @@ module.exports = {
         'css?modules&importLoaders=3&localIdentName=[name]-[local]-[hash:base64:5]',
         'sass',
         'sass-resources']
+      },
+      {
+        test: /\.less$/,
+        loaders: ['style-loader',
+        'css-loader',
+        'less-loader']
       },
       {
         test: /\.css$/,

--- a/app/client/webpack.prod.config.js
+++ b/app/client/webpack.prod.config.js
@@ -32,14 +32,11 @@ module.exports = {
         ENV: JSON.stringify(ENV)
       }
     }),
-    new webpack.optimize.AggressiveMergingPlugin(),//Merge chunks
-    // new CompressionPlugin({
-    //   asset: "[path].gz[query]",
-    //   algorithm: "gzip",
-    //   test: /\.js$|\.css$|\.html$/,
-    //   threshold: 10240,
-    //   minRatio: 0.8
-    // })
+    new webpack.optimize.AggressiveMergingPlugin(),
+    // new webpack.DllReferencePlugin({
+    //         context: path.join(__dirname, '../assets', 'javascripts', 'dll'),
+    //         manifest: require("vendor-manifest.json")
+    // }), this guy never got to work even when path and everything is good teest 1000x times
   ],
 
   module: {
@@ -47,14 +44,14 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        loader: 'babel-loader?presets[]=es2015&presets[]=react&plugins[]=lodash',
+        loader: 'babel-loader',
         include: [
-            path.join(__dirname, "client") //important for performance!
+            path.join(__dirname, "../client") //important for performance!
         ],
         query: {
             cacheDirectory: true, //important for performance
-            plugins: ["transform-regenerator"],
-            presets: ["react", "es2015", "stage-0"]
+            plugins: ["transform-regenerator", "lodash"], //try adding and removing lodash here and check how much time it adds
+            presets: ["react", "es2015"]
         }
       },
       {

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -38,9 +38,11 @@
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <% if Rails.env.development? %>
+    <%= javascript_include_tag 'http://0.0.0.0:8080/dll/dll.vendor.js' %>
     <%= javascript_include_tag 'http://0.0.0.0:8080/bundle.js' %>
   <% else %>
-    <%= javascript_include_tag 'bundle' %>
+    <%= javascript_include_tag 'https://0.0.0.0:dll/dll.vendor.js' %>
+    <%= javascript_include_tag 'https://0.0.0.0:bundle.js' %>
   <% end %>
   <meta name="turbolinks-cache-control" content="no-cache">
   <%= csrf_meta_tags %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -38,7 +38,6 @@
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <% if Rails.env.development? %>
-    <%= javascript_include_tag 'http://0.0.0.0:8080/dll/dll.vendor.js' %>
     <%= javascript_include_tag 'http://0.0.0.0:8080/bundle.js' %>
   <% else %>
     <%= javascript_include_tag 'https://0.0.0.0:dll/dll.vendor.js' %>


### PR DESCRIPTION
This is making the prod compile cca 4 seconds faster right now, which is not much but the compiled version of it might be easier to load for browsers so it should give us better score at tests. Comments next to the code are helpful. I'll be for sure checking out more since `vendor-manifest.json` doesn't want to load at all lol and based on [article](http://engineering.invisionapp.com/post/optimizing-webpack/) that inspired this, since it should _ add the DLLReferencePlugin and point it at our already built DLL._
and yeah I am talking about milliseconds in development as well, where I witnessed that on bigger piece of code with ton of shit in it.  Right now on master it takes cca 13 seconds to compile. 
p.s @s-kennedy idk if you tested that yesterday but I've seen some unexpected import so was mind forced to fix it. Idk what fixed it right now at 3:55 lol, I just did it because my stomach was off :D 

to run prod locally `npm run build:prod` then add compiled files to the repo 